### PR TITLE
Fix MIRACLReranking metric filter

### DIFF
--- a/refresh.py
+++ b/refresh.py
@@ -179,6 +179,8 @@ def filter_metric_fetched(name: str, metric: str, expected_metrics, split: str) 
         return bool(metric == "ndcg_at_1")
     elif (name.startswith("BrightRetrieval") and (split == "long")):
         return bool(metric in ["recall_at_1"])
+    elif name.startswith("MIRACLReranking"):
+        return bool(metric in ["NDCG@10(MIRACL)"])
     else:
         return bool(metric in expected_metrics)
 


### PR DESCRIPTION
Fixes an issue where models loaded from metadata could not be updated. It's ruMTEB case only as it includes MIRACLReranking. Should work for all languages.