### PR TITLE
Add arabic retrieval tab to leaderboard

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -398,7 +398,7 @@ boards:
     acronym: null
     icon: null
     special_icons: null
-    credits: null
+    credits: "[NAMAA-Space](https://huggingface.co/NAMAA-Space)"
     tasks:
       Retrieval:
         - MintakaRetrieval (ar)

--- a/config.yaml
+++ b/config.yaml
@@ -391,6 +391,22 @@ boards:
         - MassiveIntentClassification (nb)
         - MassiveScenarioClassification (nb)
         - ScalaNbClassification
+  ara:
+    title: Arabic
+    language_long: "Arabic"
+    has_overall: false
+    acronym: null
+    icon: null
+    special_icons: null
+    credits: null
+    tasks:
+      Retrieval:
+        - MintakaRetrieval (ar)
+        - MIRACLRetrieval (ar)
+        - MIRACLRetrievalHardNegatives (ar)
+        - MLQARetrieval (ara-ara)
+        - MrTidyRetrieval (arabic)
+        - XPQARetrieval (ara-ara)
   other-cls:
     title: "Other Languages"
     language_long: "47 (Only languages not included in the other tabs)"


### PR DESCRIPTION
# PR Description:
This PR introduces an Arabic retrieval tab to the MTEB leaderboard

## Purpose: 
The tab should highlight benchmarks specifically focused on Arabic retrieval tasks for better tracking of progress in this area.

## Changes:
1.  We adjusted the `config.yaml` to add a new retrieval leaderboard tab 
2.  we included the 6 different retrieval datasets. 
3. Here is also screenshots for how the leader board will look like:
<img width="1264" alt="arabic_retrieval_tab_1" src="https://github.com/user-attachments/assets/0c4822cf-b4f3-4572-a90b-93f8743060df" />
<img width="1272" alt="arabic_retrieval_tab_2" src="https://github.com/user-attachments/assets/856d6010-a136-44ef-8015-9d9a2caf319f" />
<img width="1208" alt="arabic_retrieval_tab_3" src="https://github.com/user-attachments/assets/a3636f7d-6e0c-424f-aaf4-5bad284d2cc8" />
